### PR TITLE
Switch to Redoc's CDN

### DIFF
--- a/src/redoc-html-template.ts
+++ b/src/redoc-html-template.ts
@@ -21,7 +21,7 @@ const html = `<!DOCTYPE html>
   </head>
   <body>
     <div id="redoc-container"></div>
-    <script nonce='[[nonce]]' src="https://unpkg.com/redoc@latest/bundles/redoc.standalone.js"> </script>
+    <script nonce='[[nonce]]' src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
   </body>
   <script>
     Redoc.init(


### PR DESCRIPTION
As per their docs - https://github.com/Redocly/redoc/blob/cab07bad3bd43f2cf10e00f13c017f0af3038f13/docs/deployment/html.md

I've been using this package for a while (thanks!), but have been having intermittent issues recently with fetching the redoc script from unpkg, e.g. the script being `blocked due to MIME type ("text/plain") mismatch`