### PR TITLE
Pin Redoc script source version to 2.x.x

### DIFF
--- a/src/redoc-html-template.ts
+++ b/src/redoc-html-template.ts
@@ -21,7 +21,7 @@ const html = `<!DOCTYPE html>
   </head>
   <body>
     <div id="redoc-container"></div>
-    <script nonce='[[nonce]]' src="https://unpkg.com/redoc@latest/bundles/redoc.standalone.js"> </script>
+    <script nonce='[[nonce]]' src="https://unpkg.com/redoc@^2.5.2/bundles/redoc.standalone.js"> </script>
   </body>
   <script>
     Redoc.init(


### PR DESCRIPTION
Fixes #5 by pinning the version to something other than `latest`.